### PR TITLE
Add support for configurable file type selection (and add a 1.x branch to track 1.x features)

### DIFF
--- a/config_form.php
+++ b/config_form.php
@@ -1,28 +1,38 @@
 <h3>Admin Interface</h3>
 <label for="docsviewer_embed_admin">Embed viewer in admin item show pages?</label>
-<p><?php echo __v()->formCheckbox('docsviewer_embed_admin', 
-                                  true, 
+<p><?php echo __v()->formCheckbox('docsviewer_embed_admin',
+                                  true,
                                   array('checked' => (boolean) get_option('docsviewer_embed_admin'))); ?></p>
 <label for="docsviewer_width_admin">Viewer width, in pixels:</label>
-<p><?php echo __v()->formText('docsviewer_width_admin', 
-                              get_option('docsviewer_width_admin'), 
+<p><?php echo __v()->formText('docsviewer_width_admin',
+                              get_option('docsviewer_width_admin'),
                               array('size' => 5));?></p>
 <label for="docsviewer_height_admin">Viewer height, in pixels:</label>
-<p><?php echo __v()->formText('docsviewer_height_admin', 
-                              get_option('docsviewer_height_admin'), 
+<p><?php echo __v()->formText('docsviewer_height_admin',
+                              get_option('docsviewer_height_admin'),
                               array('size' => 5));?></p>
 <h3>Public Theme</h3>
 <label for="docsviewer_embed_public">Embed viewer in public item show pages?</label>
-<p><?php echo __v()->formCheckbox('docsviewer_embed_public', 
-                                  true, 
+<p><?php echo __v()->formCheckbox('docsviewer_embed_public',
+                                  true,
                                   array('checked' => (boolean) get_option('docsviewer_embed_public'))); ?></p>
 <label for="docsviewer_width_public">Viewer width, in pixels:</label>
-<p><?php echo __v()->formText('docsviewer_width_public', 
-                              get_option('docsviewer_width_public'), 
+<p><?php echo __v()->formText('docsviewer_width_public',
+                              get_option('docsviewer_width_public'),
                               array('size' => 5));?></p>
 <label for="docsviewer_height_public">Viewer height, in pixels:</label>
-<p><?php echo __v()->formText('docsviewer_height_public', 
-                              get_option('docsviewer_height_public'), 
+<p><?php echo __v()->formText('docsviewer_height_public',
+                              get_option('docsviewer_height_public'),
                               array('size' => 5));?></p>
+
+<h3>File Formats to Display via the Docs Viewer</h3>
+<?php  $savedTypes = array_keys(unserialize(get_option('docsviewer_supported_files')));?>
+  <?php foreach(DocsViewerPlugin::$supportedFileTypes as $fileTypes => $fileTypeName): ?>
+  <div title="<?php print $fileTypeName; ?>">
+      <label style="width: 220px;" for="docsviewer_supported_files[<?php print $FileTypes; ?>]"><?php printf('%s (%s)', $fileTypeName, str_replace('|', ', ', $fileTypes)); ?></label>
+      <input type="checkbox" name="docsviewer_supported_files[<?php print $fileTypes; ?>]" <?php print (in_array($fileTypes, $savedTypes)) ? 'checked="true"' : null ?> />
+  </div>
+<?php endforeach; ?>
+
 <p>By using this service you acknowledge that you have read and agreed to the <a href="http://docs.google.com/viewer/TOS?hl=en">Google Docs Viewer Terms of Service</a>.</p>
 

--- a/plugin.php
+++ b/plugin.php
@@ -12,9 +12,24 @@ class DocsViewerPlugin
     const DEFAULT_VIEWER_EMBED = 1;
     const DEFAULT_VIEWER_WIDTH = 500;
     const DEFAULT_VIEWER_HEIGHT = 600;
-    
-    private $_supportedFiles = array('pdf', 'doc', 'ppt', 'tif', 'tiff');
-    
+
+    // http://docs.google.com/support/bin/answer.py?hl=en&answer=1189935
+    public static $supportedFileTypes = array(
+        'ai' => 'Adobe Illustrator',
+        'psd' => 'Adobe Photoshop',
+        'dxf' => 'Autodesk AutoCad',
+        'doc|docx' => 'Microsoft Word',
+        'xls|xlsx' => 'Microsoft Excel',
+        'ppt|pptx' => 'Microsoft PowerPoint',
+        'pdf' => 'Portable Document Format File',
+        'eps|ps' => 'PostScript',
+        'pps' => 'PowerPoint Slide Show',
+        'svg' => 'Scalable Vector Graphics',
+        'tif|tiff' => 'Tagged Image File Format',
+        'ttf' => 'TrueType',
+        'xps' => 'XML Paper Specification'
+    );
+
     public static function install()
     {
         set_option('docsviewer_embed_admin', DocsViewerPlugin::DEFAULT_VIEWER_EMBED);
@@ -24,69 +39,95 @@ class DocsViewerPlugin
         set_option('docsviewer_width_public', DocsViewerPlugin::DEFAULT_VIEWER_WIDTH);
         set_option('docsviewer_height_public', DocsViewerPlugin::DEFAULT_VIEWER_HEIGHT);
     }
-    
+
     public static function uninstall()
     {
         delete_option('docsviewer_width');
         delete_option('docsviewer_height');
-    } 
-    
+    }
+
     public static function configForm()
     {
         include 'config_form.php';
     }
-    
+
     public static function config($post)
     {
-        if (!is_numeric($post['docsviewer_width_admin']) || 
-            !is_numeric($post['docsviewer_height_admin']) || 
-            !is_numeric($post['docsviewer_width_public']) || 
+        if (!is_numeric($post['docsviewer_width_admin']) ||
+            !is_numeric($post['docsviewer_height_admin']) ||
+            !is_numeric($post['docsviewer_width_public']) ||
             !is_numeric($post['docsviewer_height_public'])) {
             throw new Exception('The width and height must be numeric.');
         }
+
+        // Only accept whitelisted file types
+        foreach (array_keys($post['docsviewer_supported_files']) as $type) {
+            if (!in_array($type, array_keys(self::$supportedFileTypes))) {
+                throw new Exception('Invalid File Format Submitted.');
+            }
+            else {
+                // Prevent form from injecting arbitrary values
+                $post['docsviewer_supported_files'] = array_fill_keys(array_keys($post['docsviewer_supported_files']), 'on');
+            }
+        }
+
         set_option('docsviewer_embed_admin', (int) (boolean) $post['docsviewer_embed_admin']);
         set_option('docsviewer_width_admin', $post['docsviewer_width_admin']);
         set_option('docsviewer_height_admin', $post['docsviewer_height_admin']);
         set_option('docsviewer_embed_public', (int) (boolean) $post['docsviewer_embed_public']);
         set_option('docsviewer_width_public', $post['docsviewer_width_public']);
         set_option('docsviewer_height_public', $post['docsviewer_height_public']);
+        set_option('docsviewer_supported_files', serialize($post['docsviewer_supported_files']));
     }
-    
+
+
     public static function append()
     {
         // Embed viewer only if configured to do so.
-        if ((is_admin_theme() && !get_option('docsviewer_embed_admin')) || 
+        if ((is_admin_theme() && !get_option('docsviewer_embed_admin')) ||
             (!is_admin_theme() && !get_option('docsviewer_embed_public'))) {
             return;
         }
         $docsViewer = new DocsViewerPlugin;
         $docsViewer->embed();
     }
-    
+
     public function embed()
     {
         foreach (__v()->item->Files as $file) {
             $extension = pathinfo($file->archive_filename, PATHINFO_EXTENSION);
-            if (!in_array($extension, $this->_supportedFiles)) {
+            if (!in_array($extension, self::getSupportedExtensions())) {
                 continue;
             }
 ?>
 <div>
     <h2>File: <?php echo $file->original_filename; ?></h2>
-    <iframe src="<?php echo $this->_getUrl($file); ?>" 
-            width="<?php echo is_admin_theme() ? get_option('docsviewer_width_admin') : get_option('docsviewer_width_public'); ?>" 
-            height="<?php echo is_admin_theme() ? get_option('docsviewer_height_admin') : get_option('docsviewer_height_public'); ?>" 
+    <iframe src="<?php echo $this->_getUrl($file); ?>"
+            width="<?php echo is_admin_theme() ? get_option('docsviewer_width_admin') : get_option('docsviewer_width_public'); ?>"
+            height="<?php echo is_admin_theme() ? get_option('docsviewer_height_admin') : get_option('docsviewer_height_public'); ?>"
             style="border: none;"></iframe>
 </div>
 <?php
         }
     }
-    
+
+    private function getSupportedExtensions() {
+        $docsviewer_supported_files = array_keys(unserialize(get_option('docsviewer_supported_files')));
+        foreach ($docsviewer_supported_files as $supported) {
+            $exts = (implode('|', $all_supported)) ? implode('|', $all_supported) : array($supported);
+            foreach ($exts as $ext) {
+                $valid_extensions[] = $ext;
+            }
+        }
+
+        return $valid_extensions;
+    }
+
     private function _getUrl(File $file)
     {
         require_once 'Zend/Uri.php';
         $uri = Zend_Uri::factory(self::API_URL);
-        $uri->setQuery(array('url'      => WEB_FILES . '/' . $file->archive_filename, 
+        $uri->setQuery(array('url'      => WEB_FILES . '/' . $file->archive_filename,
                              'embedded' => 'true'));
         return $uri->getUri();
     }


### PR DESCRIPTION
Not sure how much interest there is in adding features to the 1.x version of this plugin, but I needed to be able to allow administrators to pick and choose among the file types that Doc Viewer should handle. 

![docviewtypes](https://f.cloud.github.com/assets/720877/1828888/34577248-726c-11e3-8308-0900eb7b044a.png)
