### PR TITLE
allow transclusion in HTTPS

### DIFF
--- a/DocsViewerPlugin.php
+++ b/DocsViewerPlugin.php
@@ -13,7 +13,7 @@
  */
 class DocsViewerPlugin extends Omeka_Plugin_AbstractPlugin
 {
-    const API_URL = 'http://docs.google.com/viewer';
+    const API_URL = '//docs.google.com/viewer';
     
     const DEFAULT_VIEWER_EMBED = 1;
     


### PR DESCRIPTION
Many browsers either do not permit mixed HTTP and HTTPS content in a single document, or give the user a warning.  By modifying API_URL to omit explicitly mentioning HTTP as the protocol, this plugin can be used in either HTTPS-only or HTTP-enabled Omeka sites.
